### PR TITLE
Fix GitHub Actions workflow permissions for docs deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -11,6 +11,11 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
+# Set permissions at the workflow level
+permissions:
+  contents: write
+  pages: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -37,3 +42,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site
+          force_orphan: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
<!-- Thank you for contributing! Please provide a clear description below. -->
<!-- Keep it concise and focus on the key changes. -->

## Description

This PR fixes the GitHub Actions workflow for documentation deployment by adding the necessary permissions. The workflow was previously failing with a 403 error because the GitHub Actions bot didn't have write access to create and update the gh-pages branch.

## Changes Made

<!-- List the main changes made in this PR. -->
- Added explicit `contents: write` and `pages: write` permissions to the workflow
- Added `force_orphan: true` to create a clean gh-pages branch
- Configured proper user name and email for commit identification
- Improved deployment reliability for GitHub Pages

## How to Test

<!-- Describe the steps needed to test the changes you've made. -->
<!-- Include commands, specific inputs, or scenarios. -->
1. Merge the PR to the main branch
2. Check the Actions tab to see if the documentation deployment workflow runs successfully
3. Verify the documentation is properly published at https://juanfkurucz.github.io/book-reader/

## Checklist

<!-- Go through all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the style guidelines of this project (runs `ruff check .` and `ruff format .` successfully).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes (`pytest`).
- [x] Any dependent changes have been merged and published in downstream modules.

## Additional Context (Optional)

The error was occurring because the GitHub Actions bot (`github-actions[bot]`) didn't have permission to push to the repository. This is a common issue with GitHub Pages deployments from Actions. The changes in this PR follow GitHub's recommended approach for proper GitHub Pages deployment from Actions workflows.